### PR TITLE
Ligeras mejoras en terminal.

### DIFF
--- a/addons/terminal/dock.tscn
+++ b/addons/terminal/dock.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/terminal/term.gd" type="Script" id=1]
 [ext_resource path="res://addons/terminal/black.tres" type="StyleBox" id=2]
 [ext_resource path="res://addons/terminal/LiberationMono-Regular.ttf" type="DynamicFontData" id=3]
+[ext_resource path="res://addons/terminal/font.tres" type="DynamicFont" id=4]
 
 [sub_resource type="StyleBoxEmpty" id=1]
 
@@ -111,26 +112,10 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="TextEdit" type="TextEdit" parent="."]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = -1.0
-margin_right = 3.05176e-05
-margin_bottom = -20.0
-readonly = true
-syntax_highlighting = true
-smooth_scrolling = true
-wrap_enabled = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
 [node name="Title" type="RichTextLabel" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_right = 3.05176e-05
+custom_fonts/normal_font = ExtResource( 4 )
 bbcode_enabled = true
 bbcode_text = "Terminal 1.0 · RKiemGames · MIT Licence
 [tornado radius=5 freq=2][color=aqua]   ____             _         _
@@ -142,9 +127,8 @@ bbcode_text = "Terminal 1.0 · RKiemGames · MIT Licence
    | | / _ \\| '__|| '_ ` _ \\ | || '_ \\  / _` || |
    | ||  __/| |   | | | | | || || | | || (_| || |
    |_| \\___||_|   |_| |_| |_||_||_| |_| \\__,_||_|[/color][/tornado]
-LIST COMMANDS:
-[color=aqua]help[/color] [color=gray]# show this message. add --all show all.[/color]
-[color=aqua]godot[/color] [color=red]scene/file.tscn[/color] [color=gray]# run a scene.[/color]
+Type [color=aqua]help[/color] [color=gray]# show this message. add --all show all.[/color]
+Type [color=aqua]godot[/color] [color=red]scene/file.tscn[/color] [color=gray]# run a scene.[/color]
 [color=gray]# shell commands are accepted[/color]"
 text = "Terminal 1.0 · RKiemGames · MIT Licence
    ____             _         _
@@ -156,36 +140,56 @@ text = "Terminal 1.0 · RKiemGames · MIT Licence
    | | / _ \\| '__|| '_ ` _ \\ | || '_ \\  / _` || |
    | ||  __/| |   | | | | | || || | | || (_| || |
    |_| \\___||_|   |_| |_| |_||_||_| |_| \\__,_||_|
-LIST COMMANDS:
-help # show this message. add --all show all.
-godot scene/file.tscn # run a scene.
+Type help # show this message. add --all show all.
+Type godot scene/file.tscn # run a scene.
 # shell commands are accepted"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
-anchor_top = 1.0
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_top = -20.0
-margin_bottom = -8.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Prompt" type="Label" parent="HBoxContainer"]
-margin_right = 42.0
-margin_bottom = 12.0
+[node name="TextEdit" type="TextEdit" parent="VBoxContainer"]
+margin_right = 1024.0
+margin_bottom = 582.0
+size_flags_vertical = 3
+custom_fonts/font = ExtResource( 4 )
+readonly = true
+syntax_highlighting = true
+smooth_scrolling = true
+wrap_enabled = true
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 586.0
+margin_right = 1024.0
+margin_bottom = 600.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Prompt" type="Label" parent="VBoxContainer/HBoxContainer"]
+margin_right = 49.0
+margin_bottom = 14.0
+custom_fonts/font = ExtResource( 4 )
 text = "res://>"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="LineEdit" type="LineEdit" parent="HBoxContainer"]
-margin_left = 46.0
-margin_right = 118.0
-margin_bottom = 12.0
+[node name="LineEdit" type="LineEdit" parent="VBoxContainer/HBoxContainer"]
+margin_left = 53.0
+margin_right = 1024.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+custom_fonts/font = ExtResource( 4 )
 expand_to_text_length = true
 placeholder_alpha = 1.0
 caret_blink = true
@@ -203,8 +207,8 @@ window_title = "password:"
 anchor_right = 1.0
 anchor_bottom = 1.0
 secret = true
-[connection signal="gui_input" from="TextEdit" to="." method="_on_TextEdit_gui_input"]
 [connection signal="gui_input" from="Title" to="." method="_on_Title_gui_input"]
-[connection signal="gui_input" from="HBoxContainer/LineEdit" to="." method="_on_LineEdit_gui_input"]
-[connection signal="text_entered" from="HBoxContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
+[connection signal="gui_input" from="VBoxContainer/TextEdit" to="." method="_on_TextEdit_gui_input"]
+[connection signal="gui_input" from="VBoxContainer/HBoxContainer/LineEdit" to="." method="_on_LineEdit_gui_input"]
+[connection signal="text_entered" from="VBoxContainer/HBoxContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
 [connection signal="text_entered" from="Dialog/Password" to="." method="_on_Password_text_entered"]

--- a/addons/terminal/dock.tscn
+++ b/addons/terminal/dock.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/terminal/term.gd" type="Script" id=1]
 [ext_resource path="res://addons/terminal/black.tres" type="StyleBox" id=2]
-[ext_resource path="res://addons/terminal/LiberationMono-Regular.ttf" type="DynamicFontData" id=3]
 [ext_resource path="res://addons/terminal/font.tres" type="DynamicFont" id=4]
 
 [sub_resource type="StyleBoxEmpty" id=1]
@@ -15,12 +14,8 @@
 
 [sub_resource type="StyleBoxEmpty" id=5]
 
-[sub_resource type="DynamicFont" id=6]
-size = 10
-font_data = ExtResource( 3 )
-
 [sub_resource type="Theme" id=7]
-default_font = SubResource( 6 )
+default_font = ExtResource( 4 )
 LineEdit/colors/clear_button_color = Color( 0.88, 0.88, 0.88, 1 )
 LineEdit/colors/clear_button_color_pressed = Color( 1, 1, 1, 1 )
 LineEdit/colors/cursor_color = Color( 0.94, 0.94, 0.94, 1 )
@@ -115,7 +110,6 @@ __meta__ = {
 [node name="Title" type="RichTextLabel" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-custom_fonts/normal_font = ExtResource( 4 )
 bbcode_enabled = true
 bbcode_text = "Terminal 1.0 · RKiemGames · MIT Licence
 [tornado radius=5 freq=2][color=aqua]   ____             _         _
@@ -158,7 +152,6 @@ __meta__ = {
 margin_right = 1024.0
 margin_bottom = 582.0
 size_flags_vertical = 3
-custom_fonts/font = ExtResource( 4 )
 readonly = true
 syntax_highlighting = true
 smooth_scrolling = true
@@ -178,7 +171,6 @@ __meta__ = {
 [node name="Prompt" type="Label" parent="VBoxContainer/HBoxContainer"]
 margin_right = 49.0
 margin_bottom = 14.0
-custom_fonts/font = ExtResource( 4 )
 text = "res://>"
 __meta__ = {
 "_edit_use_anchors_": false
@@ -189,7 +181,6 @@ margin_left = 53.0
 margin_right = 1024.0
 margin_bottom = 14.0
 size_flags_horizontal = 3
-custom_fonts/font = ExtResource( 4 )
 expand_to_text_length = true
 placeholder_alpha = 1.0
 caret_blink = true

--- a/addons/terminal/term.gd
+++ b/addons/terminal/term.gd
@@ -1,10 +1,13 @@
 tool
 extends Control
 
+onready var InputTerminal = $VBoxContainer/HBoxContainer/LineEdit
+onready var Terminal = $VBoxContainer/TextEdit
+onready var Prompt = $VBoxContainer/HBoxContainer/Prompt
 var dir_path = '.'
 var cmd_directory = ['ls', 'dir']
 var command_history = []
-var history_file = '.history'
+var history_file = OS.get_system_dir(2)  +"/.terminal_godot_history"
 var history_enabled = false
 var current_history_index = -1
 var command_split = RegEx.new()
@@ -46,7 +49,7 @@ Report bugs to rkiemgames@gmail.com
 
 
 func _ready():
-	$TextEdit.insert_text_at_cursor("")
+	Terminal.insert_text_at_cursor("")
 	var file = File.new()
 	if file.file_exists(history_file):
 		file.open(history_file, File.READ)
@@ -61,14 +64,14 @@ func _on_LineEdit_gui_input(event):
 	if event is InputEventKey and event.scancode in [KEY_UP, KEY_DOWN] and command_history.size():
 		prints(command_history)
 		history_enabled = true
-		$HBoxContainer/LineEdit.disconnect("gui_input", self, "_on_LineEdit_gui_input")
+		InputTerminal.disconnect("gui_input", self, "_on_LineEdit_gui_input")
 		if event.scancode == KEY_UP and current_history_index > 0:
 			current_history_index -= 1
 		if event.scancode == KEY_DOWN and current_history_index < command_history.size() - 1:
 			current_history_index += 1
-		$HBoxContainer/LineEdit.text = command_history[current_history_index]
-		$HBoxContainer/LineEdit.connect("gui_input", self, "_on_LineEdit_gui_input")
-		$HBoxContainer/LineEdit.grab_focus()
+		InputTerminal.text = command_history[current_history_index]
+		InputTerminal.connect("gui_input", self, "_on_LineEdit_gui_input")
+		InputTerminal.grab_focus()
 	if event is InputEventKey and not event.scancode in [KEY_ENTER, KEY_LEFT, KEY_RIGHT, KEY_UP, KEY_DOWN]:
 		history_enabled = false
 
@@ -108,7 +111,7 @@ func parse_command(text, pipe=false):
 		if fg == bg || fg == null:
 			fg = bg.inverted()
 		$Background.color = bg
-		$TextEdit.modulate = fg
+		Terminal.modulate = fg
 		$HBoxContainer.modulate = fg
 		return
 
@@ -145,10 +148,10 @@ func parse_command(text, pipe=false):
 			print_results('directory not exists: %s' % chdir)
 			dir_path = current_dir
 			return
-		$HBoxContainer/Prompt.text = 'res://%s>' % dir_path.replace('.', '')
+		Prompt.text = 'res://%s>' % dir_path.replace('.', '')
 		return
 	if command == 'pwd':
-		print_results($HBoxContainer/Prompt.text.replace('>', ''))
+		print_results(Prompt.text.replace('>', ''))
 		return
 	if command == 'history':
 		var l = 1
@@ -170,16 +173,16 @@ func parse_command(text, pipe=false):
 	for l in output:
 		result += l
 	if command in ['reset', 'clear', 'cls']:
-		$TextEdit.text = ""
+		Terminal.text = ""
 		return
 	return result
 
 
 func print_results(result):
-	$TextEdit.cursor_set_line($TextEdit.get_line_count() - 1)
-	$TextEdit.cursor_set_column(0)
-	$TextEdit.insert_text_at_cursor("%s" % result)
-	$TextEdit.clear_undo_history()
+	Terminal.cursor_set_line(Terminal.get_line_count() - 1)
+	Terminal.cursor_set_column(0)
+	Terminal.insert_text_at_cursor("%s" % result)
+	Terminal.clear_undo_history()
 
 func update_history(text):
 	if history_enabled:
@@ -201,7 +204,7 @@ func enter_text(new_text):
 	current_history_index = command_history.size()
 	var pipe_command = new_text.split('|')
 	var result = null
-	$HBoxContainer/LineEdit.text = ""
+	InputTerminal.text = ""
 	if pipe_command.size() > 1:
 		var f = File.new()
 		var array_cmd = []
@@ -231,11 +234,11 @@ func _on_LineEdit_text_entered(new_text):
 
 
 func _on_Title_gui_input(event):
-	$HBoxContainer/LineEdit.grab_focus()
+	InputTerminal.grab_focus()
 
 
 func _on_TextEdit_gui_input(event):
-	$HBoxContainer/LineEdit.grab_focus()
+	InputTerminal.grab_focus()
 
 
 func _on_Password_text_entered(new_text):


### PR DESCRIPTION
Los cambios que hice fueron los siguientes:

- Añadí la fuente a los textos con un font.tres, porque se veía un poco mas pequeño, le activé el filter para que no se vea pixelado.

- Cambié la ubicación del archivo .history y lo renombré a .terminal_godot_history, ahora se almacenará en el folder Documentos del usuario, según el caso, usando el método: OS.get_system_dir(2)

- Modifiqué la estructura de la escena para hacerla un poco mas adaptable.

- Eliminé una línea del texto que aparece al inicio porque no calzaba bien, pero agregué la palabra Type en las siguiente líneas en sustitución.

**No se puede hacer merge automaticamente por otro pull request, supongo que deberías conservar mis cambios en term.gd, luego actualizar la ruta de los nodos:**

```
onready var InputTerminal = $VBoxContainer/HBoxContainer/LineEdit
onready var Terminal = $VBoxContainer/TextEdit
onready var Prompt = $VBoxContainer/HBoxContainer/Prompt
```

Con eso debería ser suficiente.