### PR TITLE
Minimal changes for godot 4 support.

### DIFF
--- a/addons/terminal/dock.tscn
+++ b/addons/terminal/dock.tscn
@@ -1,25 +1,25 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=3 format=3 uid="uid://dauohnpg13v10"]
 
-[ext_resource path="res://addons/terminal/term.gd" type="Script" id=1]
-[ext_resource path="res://addons/terminal/theme/theme.tres" type="Theme" id=2]
+[ext_resource type="Script" path="res://addons/terminal/term.gd" id="1"]
+[ext_resource type="Theme" uid="uid://e0bhip2pr623" path="res://addons/terminal/theme/theme.tres" id="2"]
 
-[node name="Control" type="Control"]
+[node name="Terminal" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-rect_min_size = Vector2( 0, 226 )
+rect_min_size = Vector2(0, 226)
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme = ExtResource( 2 )
-script = ExtResource( 1 )
+theme = ExtResource( "2" )
+script = ExtResource( "1" )
 __meta__ = {
-"_edit_horizontal_guides_": [ 280.0 ],
+"_edit_horizontal_guides_": [280.0],
 "_edit_use_anchors_": false
 }
 
 [node name="Background" type="ColorRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color( 0, 0, 0, 1 )
+color = Color(0, 0, 0, 1)
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -27,14 +27,7 @@ __meta__ = {
 [node name="TextEdit" type="TextEdit" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = -1.0
-margin_right = 3.05176e-05
-margin_bottom = -20.0
-readonly = true
-syntax_highlighting = true
-smooth_scrolling = true
-wrap_enabled = true
+offset_bottom = -43.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -42,24 +35,8 @@ __meta__ = {
 [node name="Title" type="RichTextLabel" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 4.0
-margin_right = 3.05176e-05
-bbcode_enabled = true
-bbcode_text = "Terminal {version} · RKiemGames · MIT Licence
-[tornado radius=5 freq=2][color=aqua]   ____             _         _
-  / ___|  ___    __| |  ___  | |_
- | |  _  / _ \\  / _` | / _ \\ | __|
- | |_| || (_) || (_| || (_) || |_
-  \\____| \\___/  \\__,_| \\___/  \\__|             [/color][color=red]_
- |_   _|___  _ __  _ __ ___  (_) _ __    __ _ | |
-   | | / _ \\| '__|| '_ ` _ \\ | || '_ \\  / _` || |
-   | ||  __/| |   | | | | | || || | | || (_| || |
-   |_| \\___||_|   |_| |_| |_||_||_| |_| \\__,_||_|[/color][/tornado]
-
-Type [color=aqua]intro[/color] [color=gray]# show this message. add --help show all.[/color]
-Type [color=aqua]godot[/color] [color=red]scene/file.tscn[/color] [color=gray]# run a scene.[/color]
-[color=gray]# shell commands work![/color]"
-text = "Terminal {version} · RKiemGames · MIT Licence
+theme_override_font_sizes/normal_font_size = 16
+text = "Terminal 1.2.4 · RKiemGames · MIT Licence
    ____             _         _
   / ___|  ___    __| |  ___  | |_
  | |  _  / _ \\  / _` | / _ \\ | __|
@@ -73,6 +50,7 @@ text = "Terminal {version} · RKiemGames · MIT Licence
 Type intro # show this message. add --help show all.
 Type godot scene/file.tscn # run a scene.
 # shell commands work!"
+bbcode_enabled = true
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -81,24 +59,27 @@ __meta__ = {
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_top = -20.0
-margin_bottom = -8.0
+offset_left = 2.0
+offset_top = -42.0
+offset_right = 2.0
+offset_bottom = -20.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Prompt" type="Label" parent="HBoxContainer"]
-margin_right = 49.0
-margin_bottom = 14.0
+offset_right = 70.0
+offset_bottom = 22.0
 text = "res://>"
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="LineEdit" type="LineEdit" parent="HBoxContainer"]
-margin_left = 53.0
-margin_right = 137.0
-margin_bottom = 14.0
+offset_left = 74.0
+offset_right = 114.0
+offset_bottom = 22.0
+theme_override_font_sizes/font_size = 16
 expand_to_text_length = true
 placeholder_alpha = 1.0
 caret_blink = true
@@ -106,12 +87,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Dialog" type="WindowDialog" parent="."]
-margin_top = -64.0
-margin_right = 330.0
-margin_bottom = -32.0
-popup_exclusive = true
-window_title = "Credentials:"
+[node name="Dialog" type="Node" parent="."]
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -119,11 +95,7 @@ __meta__ = {
 [node name="User" type="LineEdit" parent="Dialog"]
 visible = false
 anchor_right = 1.0
-margin_left = 5.0
-margin_top = 5.0
-margin_right = -5.00003
-margin_bottom = 24.0
-rect_min_size = Vector2( 0, 24 )
+rect_min_size = Vector2(0, 24)
 placeholder_text = "Username"
 placeholder_alpha = 0.363
 __meta__ = {
@@ -131,21 +103,19 @@ __meta__ = {
 }
 
 [node name="Password" type="LineEdit" parent="Dialog"]
+visible = false
 anchor_top = 0.5
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_left = 5.0
-margin_top = -12.0
-margin_right = -5.0
-margin_bottom = -5.0
-rect_min_size = Vector2( 0, 24 )
+rect_min_size = Vector2(0, 24)
 secret = true
 placeholder_text = "Password"
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
 [connection signal="gui_input" from="TextEdit" to="." method="_on_TextEdit_gui_input"]
 [connection signal="gui_input" from="Title" to="." method="_on_Title_gui_input"]
 [connection signal="gui_input" from="HBoxContainer/LineEdit" to="." method="_on_LineEdit_gui_input"]
-[connection signal="text_entered" from="HBoxContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
-[connection signal="text_entered" from="Dialog/Password" to="." method="_on_Password_text_entered"]
+[connection signal="text_submitted" from="HBoxContainer/LineEdit" to="." method="_on_LineEdit_text_entered"]
+[connection signal="text_submitted" from="Dialog/Password" to="." method="_on_Password_text_entered"]

--- a/addons/terminal/plugin.gd
+++ b/addons/terminal/plugin.gd
@@ -1,13 +1,16 @@
-tool
+@tool
 extends EditorPlugin
 
-var dock
+var dock : Node
 
 func _enter_tree():
-	dock = preload("res://addons/terminal/dock.tscn").instance()
+	dock = preload("res://addons/terminal/dock.tscn").instantiate()
 	
 	add_control_to_bottom_panel(dock, "Terminal")
+	#add_control_to_dock(DOCK_SLOT_RIGHT_BR, dock)
+	
 
 func _exit_tree():
 	remove_control_from_bottom_panel(dock)
+	#remove_control_from_docks(dock) # Remove the dock
 	dock.queue_free()

--- a/addons/terminal/theme/theme.tres
+++ b/addons/terminal/theme/theme.tres
@@ -1,83 +1,84 @@
-[gd_resource type="Theme" load_steps=5 format=2]
+[gd_resource type="Theme" load_steps=6 format=3 uid="uid://e0bhip2pr623"]
 
-[ext_resource path="res://addons/terminal/theme/black.tres" type="StyleBox" id=1]
-[ext_resource path="res://addons/terminal/theme/LiberationMono-Regular.ttf" type="DynamicFontData" id=2]
+[ext_resource type="StyleBox" path="res://addons/terminal/theme/black.tres" id="1"]
+[ext_resource type="FontData" uid="uid://j8kl01ai7pwh" path="res://addons/terminal/theme/LiberationMono-Regular.ttf" id="2"]
 
-[sub_resource type="StyleBoxEmpty" id=1]
+[sub_resource type="Font" id="2"]
+data/0 = ExtResource( "2" )
 
-[sub_resource type="DynamicFont" id=2]
-size = 12
-use_filter = true
-font_data = ExtResource( 2 )
+[sub_resource type="StyleBoxEmpty" id="1"]
+
+[sub_resource type="Font" id="Font_3ckrx"]
+data/0 = ExtResource( "2" )
 
 [resource]
-default_font = SubResource( 2 )
-LineEdit/colors/clear_button_color = Color( 0.88, 0.88, 0.88, 1 )
-LineEdit/colors/clear_button_color_pressed = Color( 1, 1, 1, 1 )
-LineEdit/colors/cursor_color = Color( 0.94, 0.94, 0.94, 1 )
-LineEdit/colors/font_color = Color( 0.88, 0.88, 0.88, 1 )
-LineEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
-LineEdit/colors/font_color_uneditable = Color( 0.88, 0.88, 0.88, 0.5 )
-LineEdit/colors/selection_color = Color( 0.49, 0.49, 0.49, 1 )
+default_font = SubResource( "Font_3ckrx" )
+LineEdit/colors/clear_button_color = Color(0.88, 0.88, 0.88, 1)
+LineEdit/colors/clear_button_color_pressed = Color(1, 1, 1, 1)
+LineEdit/colors/cursor_color = Color(0.94, 0.94, 0.94, 1)
+LineEdit/colors/font_color = Color(0.88, 0.88, 0.88, 1)
+LineEdit/colors/font_color_selected = Color(0, 0, 0, 1)
+LineEdit/colors/font_color_uneditable = Color(0.88, 0.88, 0.88, 0.5)
+LineEdit/colors/selection_color = Color(0.49, 0.49, 0.49, 1)
 LineEdit/constants/minimum_spaces = 12
-LineEdit/fonts/font = null
+LineEdit/fonts/font = SubResource( "2" )
 LineEdit/icons/clear = null
-LineEdit/styles/focus = SubResource( 1 )
-LineEdit/styles/normal = SubResource( 1 )
+LineEdit/styles/focus = SubResource( "1" )
+LineEdit/styles/normal = SubResource( "1" )
 LineEdit/styles/read_only = null
-RichTextLabel/colors/default_color = Color( 1, 1, 1, 1 )
-RichTextLabel/colors/font_color_selected = Color( 0.49, 0.49, 0.49, 1 )
-RichTextLabel/colors/font_color_shadow = Color( 0, 0, 0, 0 )
-RichTextLabel/colors/selection_color = Color( 0.1, 0.1, 1, 0.8 )
+RichTextLabel/colors/default_color = Color(1, 1, 1, 1)
+RichTextLabel/colors/font_color_selected = Color(0.49, 0.49, 0.49, 1)
+RichTextLabel/colors/font_color_shadow = Color(0, 0, 0, 0)
+RichTextLabel/colors/selection_color = Color(0.1, 0.1, 1, 0.8)
 RichTextLabel/constants/line_separation = 1
 RichTextLabel/constants/shadow_as_outline = 0
 RichTextLabel/constants/shadow_offset_x = 1
 RichTextLabel/constants/shadow_offset_y = 1
 RichTextLabel/constants/table_hseparation = 3
 RichTextLabel/constants/table_vseparation = 3
-RichTextLabel/fonts/bold_font = null
-RichTextLabel/fonts/bold_italics_font = null
-RichTextLabel/fonts/italics_font = null
-RichTextLabel/fonts/mono_font = null
-RichTextLabel/fonts/normal_font = null
+RichTextLabel/fonts/bold_font = SubResource( "2" )
+RichTextLabel/fonts/bold_italics_font = SubResource( "2" )
+RichTextLabel/fonts/italics_font = SubResource( "2" )
+RichTextLabel/fonts/mono_font = SubResource( "2" )
+RichTextLabel/fonts/normal_font = SubResource( "2" )
 RichTextLabel/styles/focus = null
-RichTextLabel/styles/normal = ExtResource( 1 )
-TextEdit/colors/background_color = Color( 0, 0, 0, 0 )
-TextEdit/colors/bookmark_color = Color( 0.08, 0.49, 0.98, 1 )
-TextEdit/colors/brace_mismatch_color = Color( 1, 0.2, 0.2, 1 )
-TextEdit/colors/breakpoint_color = Color( 0.8, 0.8, 0.4, 0.2 )
-TextEdit/colors/caret_background_color = Color( 0, 0, 0, 1 )
-TextEdit/colors/caret_color = Color( 0.88, 0.88, 0.88, 1 )
-TextEdit/colors/code_folding_color = Color( 0.8, 0.8, 0.8, 0.8 )
-TextEdit/colors/completion_background_color = Color( 0.17, 0.16, 0.2, 1 )
-TextEdit/colors/completion_existing_color = Color( 0.87, 0.87, 0.87, 0.13 )
-TextEdit/colors/completion_font_color = Color( 0.67, 0.67, 0.67, 1 )
-TextEdit/colors/completion_scroll_color = Color( 1, 1, 1, 1 )
-TextEdit/colors/completion_selected_color = Color( 0.26, 0.26, 0.27, 1 )
-TextEdit/colors/current_line_color = Color( 0.25, 0.25, 0.26, 0.8 )
-TextEdit/colors/executing_line_color = Color( 0.2, 0.8, 0.2, 0.4 )
-TextEdit/colors/font_color = Color( 0.88, 0.88, 0.88, 1 )
-TextEdit/colors/font_color_readonly = Color( 0.88, 0.88, 0.88, 0.5 )
-TextEdit/colors/font_color_selected = Color( 0, 0, 0, 1 )
-TextEdit/colors/function_color = Color( 0.4, 0.64, 0.81, 1 )
-TextEdit/colors/line_number_color = Color( 0.67, 0.67, 0.67, 0.4 )
-TextEdit/colors/mark_color = Color( 1, 0.4, 0.4, 0.4 )
-TextEdit/colors/member_variable_color = Color( 0.9, 0.31, 0.35, 1 )
-TextEdit/colors/number_color = Color( 0.92, 0.58, 0.2, 1 )
-TextEdit/colors/safe_line_number_color = Color( 0.67, 0.78, 0.67, 0.6 )
-TextEdit/colors/selection_color = Color( 0.49, 0.49, 0.49, 1 )
-TextEdit/colors/symbol_color = Color( 0.94, 0.94, 0.94, 1 )
-TextEdit/colors/word_highlighted_color = Color( 0.8, 0.9, 0.9, 0.15 )
+RichTextLabel/styles/normal = ExtResource( "1" )
+TextEdit/colors/background_color = Color(0, 0, 0, 0)
+TextEdit/colors/bookmark_color = Color(0.08, 0.49, 0.98, 1)
+TextEdit/colors/brace_mismatch_color = Color(1, 0.2, 0.2, 1)
+TextEdit/colors/breakpoint_color = Color(0.8, 0.8, 0.4, 0.2)
+TextEdit/colors/caret_background_color = Color(0, 0, 0, 1)
+TextEdit/colors/caret_color = Color(0.88, 0.88, 0.88, 1)
+TextEdit/colors/code_folding_color = Color(0.8, 0.8, 0.8, 0.8)
+TextEdit/colors/completion_background_color = Color(0.17, 0.16, 0.2, 1)
+TextEdit/colors/completion_existing_color = Color(0.87, 0.87, 0.87, 0.13)
+TextEdit/colors/completion_font_color = Color(0.67, 0.67, 0.67, 1)
+TextEdit/colors/completion_scroll_color = Color(1, 1, 1, 1)
+TextEdit/colors/completion_selected_color = Color(0.26, 0.26, 0.27, 1)
+TextEdit/colors/current_line_color = Color(0.25, 0.25, 0.26, 0.8)
+TextEdit/colors/executing_line_color = Color(0.2, 0.8, 0.2, 0.4)
+TextEdit/colors/font_color = Color(0.88, 0.88, 0.88, 1)
+TextEdit/colors/font_color_readonly = Color(0.88, 0.88, 0.88, 0.5)
+TextEdit/colors/font_color_selected = Color(0, 0, 0, 1)
+TextEdit/colors/function_color = Color(0.4, 0.64, 0.81, 1)
+TextEdit/colors/line_number_color = Color(0.67, 0.67, 0.67, 0.4)
+TextEdit/colors/mark_color = Color(1, 0.4, 0.4, 0.4)
+TextEdit/colors/member_variable_color = Color(0.9, 0.31, 0.35, 1)
+TextEdit/colors/number_color = Color(0.92, 0.58, 0.2, 1)
+TextEdit/colors/safe_line_number_color = Color(0.67, 0.78, 0.67, 0.6)
+TextEdit/colors/selection_color = Color(0.49, 0.49, 0.49, 1)
+TextEdit/colors/symbol_color = Color(0.94, 0.94, 0.94, 1)
+TextEdit/colors/word_highlighted_color = Color(0.8, 0.9, 0.9, 0.15)
 TextEdit/constants/completion_lines = 7
 TextEdit/constants/completion_max_width = 50
 TextEdit/constants/completion_scroll_width = 3
 TextEdit/constants/line_spacing = 4
-TextEdit/fonts/font = null
+TextEdit/fonts/font = SubResource( "2" )
 TextEdit/icons/fold = null
 TextEdit/icons/folded = null
 TextEdit/icons/space = null
 TextEdit/icons/tab = null
 TextEdit/styles/completion = null
-TextEdit/styles/focus = SubResource( 1 )
-TextEdit/styles/normal = SubResource( 1 )
-TextEdit/styles/read_only = SubResource( 1 )
+TextEdit/styles/focus = SubResource( "1" )
+TextEdit/styles/normal = SubResource( "1" )
+TextEdit/styles/read_only = SubResource( "1" )

--- a/project.godot
+++ b/project.godot
@@ -6,21 +6,21 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
+config_version=5
 
-_global_script_classes=[  ]
+_global_script_classes=[]
 _global_script_class_icons={
-
 }
 
 [application]
 
 config/name="Terminal"
 config/icon="res://icon.png"
+config/features=PackedStringArray("4.0")
 
 [editor_plugins]
 
-enabled=PoolStringArray( "terminal" )
+enabled=PackedStringArray("res://addons/terminal/plugin.cfg")
 
 [rendering]
 


### PR DESCRIPTION
Godot Version: Godot_v4.0-dev.20211210_win64

Change Log:
- The manual changes are primarily in plugin.gd and term.gd.
- There was some dragging of the prompt HBox to prevent overlapping with the bottom tabs.
- Manually re-created the FontData `.tres` because DynamicFont was removed in v4. 
- The rest was automatically updated when loaded into Godot 4 

**Note**: There are still things that need migrating but this PR is the minimal amount needed to get the Terminal tab to load in the bottom pane and allow rudimentary command execution. This was only tested in Windows and I didn't test any of the internal commands, only simple things like `dir` and `git`.